### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "node server.js",
     "lint": "eslint **/*.js --quiet",
+    "mocha": "cross-env NODE_ENV=test mocha -u tdd --reporter spec --exit",
     "fix": "eslint --fix .",
-    "test": "npm run lint && cross-env NODE_ENV=test mocha -u tdd --reporter spec --exit"
+    "test": "npm run lint && npm run mocha"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
add fix from Jason

"Jason - Tue / Thu Instructor [8:06 PM]
Since multiple teams have had an issue with failing lint keeping their tests from running at all, here’s an alternative version of the “scripts” section for package.json that permits running `lint` and `mocha` independently"